### PR TITLE
Revert "[Security] Bump django from 1.10.4 to 2.1.5"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,15 +8,14 @@ certifi==2018.11.29       # via requests
 chardet==3.0.4            # via requests
 django-amber==0.8.0
 django-appconf==1.0.2     # via django-compressor
-django-compressor==2.2
 django-dotenv==1.4.2
 django-markdown-deux==1.0.5
-django==2.1.5
+django==1.10.4
+django_compressor==2.2
 http-crawler==0.1.2       # via django-amber
 idna==2.8                 # via requests
 lxml==3.7.1               # via http-crawler
 markdown2==2.3.7          # via django-markdown-deux
-pytz==2018.9              # via django
 pyyaml==3.12              # via django-amber
 rcssmin==1.0.6            # via django-compressor
 requests==2.21.0


### PR DESCRIPTION
Reverts PyconUK/uk.python.org#56

This breaks the site build, but Travis doesn't currently test this for PRs, cf. #58 