### PR TITLE
Remove DJANGO_AMBER_CNAME

### DIFF
--- a/ukpython/settings.py
+++ b/ukpython/settings.py
@@ -125,8 +125,6 @@ MARKDOWN_DEUX_STYLES = {
 
 # Django Amber
 
-DJANGO_AMBER_CNAME = 'uk.python.org'
-
 DJANGO_AMBER_CRAWL_OPTIONS = {
     'follow_external_links': False,
 }


### PR DESCRIPTION
The current canonical way to configure a GitHub Pages site for a custom domain is now via Settings, not a CNAME file

DJANGO_AMBER_CNAME violates the principle of least surprise as on build, it overrides what has been set in Settings...!