### PR TITLE
Re-add DJANGO_AMBER_CNAME

### DIFF
--- a/ukpython/settings.py
+++ b/ukpython/settings.py
@@ -125,6 +125,8 @@ MARKDOWN_DEUX_STYLES = {
 
 # Django Amber
 
+DJANGO_AMBER_CNAME = "community.uk.python.org"
+
 DJANGO_AMBER_CRAWL_OPTIONS = {
     'follow_external_links': False,
 }


### PR DESCRIPTION
This (effectively) reverts f9ec39216575bc92eeb132b7228ba5d34f03c78b but with the new hostname

Removing it means that new, scheduled builds (for the events scraper) remove the CNAME file auto-created by the GitHub Settings UI, and thus remove the config.

It looks like this needs to be the canonical way to set the domain config given the deployment setup